### PR TITLE
Исправлена ошибка, когда сервер завершался по ошибке

### DIFF
--- a/player.py
+++ b/player.py
@@ -114,7 +114,8 @@ class Player:
 
     def receive(self, jdt):
         try:
-            self.handle_messages()
+            if self.bp is not None:
+                self.handle_messages()
 
             self.last_request = datetime.today().timestamp()
 


### PR DESCRIPTION
Тип: ошибка
Предположительная причина: событие во время входа игрока (выход, вход, выстрел игрока)
Дополнительно: до отправки игроком "get_battle_data" (и из-за этого изменения значения self.bp), вызывалась функция "self.handle_messages()", которая пыталась получить значение из self.bp (self.bp было = None)

Действительная причина не установлена